### PR TITLE
Add setup.py to make cms installable by python package tools

### DIFF
--- a/cms/__init__.py
+++ b/cms/__init__.py
@@ -1,0 +1,2 @@
+__version__ = "2012.05.07"
+VERSION = tuple(map(int, __version__.split('.')))

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+import cms
+from setuptools import setup, find_packages
+from setuptools.command.test import test
+
+setup(
+    name='djangocms2000',
+    version=cms.__version__,
+    description='Flexible Django CMS with edit-in-place capability',
+    long_description=open('readme.markdown').read(),
+    author='Greg Brown',
+    author_email='greg@gregbrown.co.nz',
+    url='https://github.com/gregplaysguitar/djangocms2000',
+    packages=find_packages(exclude=['tests', 'tests.*']),
+    platforms='any',
+    zip_safe=False,
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Environment :: Web Environment',
+        'Intended Audience :: Developers',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
+        'Framework :: Django',
+    ],
+)


### PR DESCRIPTION
Fixes https://github.com/gregplaysguitar/djangocms2000/issues/2

Not sure about the version; it's going to have to be bumped to allow upgrades via e.g. pip -U.
