### PR TITLE
Change message for empty edit block

### DIFF
--- a/cms/templates/cms/cms/block_editor.html
+++ b/cms/templates/cms/cms/block_editor.html
@@ -5,12 +5,11 @@
       data-save_url="{% url 'cms.views.saveblock' block.id %}"
       data-format="{{ block.format }}">
 	<input type="hidden" name="content" value="{{ block.content }}">
-
 	<span class="cms-inner">
 		{% if block.content %}
 			{{ rendered_content }}
 		{% else %}
-			Click to add text {{ block.label }}
+			Click to add text <span class="label-name">{{ block.label }}</span>
 		{% endif %}
 	</span>
 </span>

--- a/cms/templates/cms/cms/block_editor.html
+++ b/cms/templates/cms/cms/block_editor.html
@@ -1,16 +1,16 @@
 {% load url from future %}
 
-<span class="cms-block {{ block.format }} 
+<span class="cms-block {{ block.format }}
              {% if not block.content %}placeholder{% endif %}"
       data-save_url="{% url 'cms.views.saveblock' block.id %}"
       data-format="{{ block.format }}">
 	<input type="hidden" name="content" value="{{ block.content }}">
-	
+
 	<span class="cms-inner">
 		{% if block.content %}
 			{{ rendered_content }}
 		{% else %}
-			Click to add text
+			Click to add text {{ block.label }}
 		{% endif %}
 	</span>
 </span>


### PR DESCRIPTION
Hey Greg,

As i said I would I've changed the default for when an editor block is empty. My reasoning is that ideally there's some sort of indication of what a block is for when it's blank.

I've briefly checked my local instance of marl that this is working as expected.